### PR TITLE
Update jquery.dialogOptions.js

### DIFF
--- a/jquery.dialogOptions.js
+++ b/jquery.dialogOptions.js
@@ -48,10 +48,11 @@ $.ui.dialog.prototype._init = function () {
     _init.apply(this, arguments);
 
     //patch
-    $.ui.dialog.overlay.events = $.map('focus,keydown,keypress'.split(','), function (event) {
-        return event + '.dialog-overlay';
-    }).join(' ');
-
+    if ($.ui && $.ui.dialog && $.ui.dialog.overlay) {
+        $.ui.dialog.overlay.events = $.map('focus,keydown,keypress'.split(','), function (event) {
+           return event + '.dialog-overlay';
+       }).join(' ');
+    }
 };
 // end _init
 


### PR DESCRIPTION
Added an "if" clause to line 51 to fix the error "Uncaught TypeError: Cannot set property 'events' of undefined" when creating a dialog, using jquery UI 1.10 and upward.

This completely eliminated both the error message and the symptoms for me.
