### PR TITLE
Fix error with IE8 and earlier

### DIFF
--- a/jquery.dialogOptions.js
+++ b/jquery.dialogOptions.js
@@ -118,9 +118,11 @@ $.ui.dialog.prototype.open = function () {
     });
 
     // resize on orientation change
-    window.addEventListener("orientationchange", function () {
-        resize();
-    });
+     if (window.addEventListener) {  // Add extra condition because IE8 doesn't support addEventListener (or orientationchange)
+        window.addEventListener("orientationchange", function () {
+            resize();
+        });
+    }
 
     // hide titlebar
     if (!self.options.showTitleBar) {


### PR DESCRIPTION
IE8 and earlier don't support window.addEventListener so line 121 of jQuery.dialogOptions.js causes an error 

Amended to only use window.addEventListener if it is supported.  If not then don't try to add
the eventListener for orientationchange. 
